### PR TITLE
feature: set suki-ui reference namespace in .axaml file.

### DIFF
--- a/SukiUI.Demo/App.axaml
+++ b/SukiUI.Demo/App.axaml
@@ -3,7 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:common="clr-namespace:SukiUI.Demo.Common"
-             xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              RequestedThemeVariant="Default">
     <Application.DataTemplates>
         <common:ViewLocator />
@@ -22,7 +22,7 @@
         
         <StyleInclude Source="avares://Avalonia.Controls.ColorPicker/Themes/Fluent/Fluent.xaml" />
         <StyleInclude Source="avares://AvaloniaEdit/Themes/Fluent/AvaloniaEdit.xaml" />
-        <sukiUi:SukiTheme ThemeColor="Blue"/>
+        <suki:SukiTheme ThemeColor="Blue"/>
         <StyleInclude Source="avares://SukiUI.Demo/Styles/ShowMeTheXamlStyles.axaml" />
         <StyleInclude Source="avares://SukiUI.Demo/Styles/WrapPanelStyles.axaml" />
         <StyleInclude Source="avares://SukiUI.Demo/Styles/TextStyles.axaml" />

--- a/SukiUI.Demo/Features/ControlsLibrary/ButtonsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ButtonsView.axaml
@@ -1,12 +1,11 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ButtonsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:ButtonsViewModel"
@@ -14,14 +13,14 @@
     <UserControl.Styles>
         <Style Selector="Button">
             <Setter Property="Content" Value="Button" />
-            <Setter Property="theme:ButtonExtensions.ShowProgress" Value="{Binding IsBusy}" />
+            <Setter Property="suki:ButtonExtensions.ShowProgress" Value="{Binding IsBusy}" />
             <Setter Property="Command" Value="{Binding ButtonClickedCommand}" />
             <Setter Property="IsEnabled" Value="{Binding IsEnabled}" />
         </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Buttons">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Buttons">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI has a handful of button styles, available in both the standard primary color, but also in the theme's accent color.
@@ -40,95 +39,95 @@
 
                     </StackPanel>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Standard Button">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Standard Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button1">
                             <Button />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Basic Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Basic Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button2">
                             <Button Classes="Basic" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Flat Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Flat Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button3">
                             <Button Classes="Flat" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Flat Rounded Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Flat Rounded Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button4">
                             <Button Classes="Rounded Flat" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Outlined Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Outlined Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button5">
                             <Button Classes="Outlined" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Standard Accent Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Standard Accent Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button6">
                             <Button Classes="Accent" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Basic Accent Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Basic Accent Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button7">
                             <Button Classes="Basic Accent" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Flat Accent Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Flat Accent Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button8">
                             <Button Classes="Flat Accent" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Flat Rounded Accent Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Flat Rounded Accent Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button9">
                             <Button Classes="Rounded Flat Accent" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Outlined Accent Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Outlined Accent Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button10">
                             <Button Classes="Outlined Accent" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Busy Button">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Busy Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button11">
-                            <Button theme:ButtonExtensions.ShowProgress="True" />
+                            <Button suki:ButtonExtensions.ShowProgress="True" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Large Button">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Large Button">
                         <showMeTheXaml:XamlDisplay UniqueId="Button12">
                             <Button Classes="Flat Large" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CardsView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.CardsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,14 +12,14 @@
              x:DataType="controlsLibrary:CardsViewModel"
              mc:Ignorable="d">
     <UserControl.Styles>
-        <Style Selector="WrapPanel &gt; controls|GlassCard">
+        <Style Selector="WrapPanel &gt; suki|GlassCard">
             <Setter Property="IsOpaque" Value="{Binding IsOpaque}" />
             <Setter Property="IsInteractive" Value="{Binding IsInteractive}" />
         </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Cards">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Cards">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI provides a simple GlassCard control which has some basic customisation built in.
@@ -44,34 +44,34 @@
                      
                     </DockPanel>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <StackPanel>
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Standard">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Standard">
                         <TextBlock Classes="h3">A standard GlassCard</TextBlock>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard Classes="Primary">
-                    <controls:GroupBox Header="Primary">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard Classes="Primary">
+                    <suki:GroupBox Header="Primary">
                         <TextBlock Classes="h3">A primary colored GlassCard</TextBlock>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard Classes="Accent">
-                    <controls:GroupBox Header="Accent">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard Classes="Accent">
+                    <suki:GroupBox Header="Accent">
                         <TextBlock Classes="h3">An accent colored GlassCard</TextBlock>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GlassCard.Resources>
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GlassCard.Resources>
                         <system:Double x:Key="GlassOpacity">0.2</system:Double>
-                    </controls:GlassCard.Resources>
-                    <controls:GroupBox Header="Overriden Opacity">
+                    </suki:GlassCard.Resources>
+                    <suki:GroupBox Header="Overriden Opacity">
                         <TextBlock Classes="h4">This card's resources sets the double resource of "GlassOpacity" to 0.2</TextBlock>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
                
             </WrapPanel>
                 
@@ -84,15 +84,15 @@
                 </StackPanel>
                 
                 <Grid ColumnDefinitions="*,*" Margin="15">
-                    <controls:GlassCard HorizontalAlignment="Left" IsAnimated="False" Margin="15">
+                    <suki:GlassCard HorizontalAlignment="Left" IsAnimated="False" Margin="15">
                         <StackPanel Spacing="35">
                             <TextBlock FontWeight="DemiBold" FontSize="17" Text="Not Animated"></TextBlock>
                             <ItemsControl  ItemsSource="{Binding Items}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <controls:GlassCard helpers:AnimationExtensions.FadeIn="500" Width="150" Height="60" Margin="5" IsInteractive="True">
+                                        <suki:GlassCard helpers:AnimationExtensions.FadeIn="500" Width="150" Height="60" Margin="5" IsInteractive="True">
                                            <TextBlock Text="Item" Foreground="{DynamicResource SukiLowText}"></TextBlock>
-                                        </controls:GlassCard>
+                                        </suki:GlassCard>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                                 <ItemsControl.ItemsPanel>
@@ -102,17 +102,17 @@
                                 </ItemsControl.ItemsPanel>
                             </ItemsControl>
                         </StackPanel>
-                    </controls:GlassCard>
+                    </suki:GlassCard>
                     
-                    <controls:GlassCard Grid.Column="1" HorizontalAlignment="Left"  Margin="15">
+                    <suki:GlassCard Grid.Column="1" HorizontalAlignment="Left"  Margin="15">
                         <StackPanel Spacing="35">
                             <TextBlock FontWeight="DemiBold" FontSize="17" Text="Animated"></TextBlock>
                             <ItemsControl  ItemsSource="{Binding Items}">
                                 <ItemsControl.ItemTemplate>
                                     <DataTemplate>
-                                        <controls:GlassCard helpers:AnimationExtensions.FadeIn="500" Width="150" Height="60" Margin="5" IsInteractive="True">
+                                        <suki:GlassCard helpers:AnimationExtensions.FadeIn="500" Width="150" Height="60" Margin="5" IsInteractive="True">
                                             <TextBlock Text="Item" Foreground="{DynamicResource SukiLowText}"></TextBlock>
-                                        </controls:GlassCard>
+                                        </suki:GlassCard>
                                     </DataTemplate>
                                 </ItemsControl.ItemTemplate>
                                 <ItemsControl.ItemsPanel>
@@ -122,7 +122,7 @@
                                 </ItemsControl.ItemsPanel>
                             </ItemsControl>
                         </StackPanel>
-                    </controls:GlassCard>
+                    </suki:GlassCard>
                 </Grid>
                 <Border Height="100"></Border>
             </StackPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/CollectionsView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.CollectionsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -13,8 +13,8 @@
              x:DataType="controlsLibrary:CollectionsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Collections">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Collections">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         All basic collection controls have been styled and animated.
@@ -23,29 +23,29 @@
                         The DataGrid aligns it's content to the left by default, but you can apply CenterAlign and LeftAlign classes to the CellStyleClasses property of a column definition.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="ListBox">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="ListBox">
                         <showMeTheXaml:XamlDisplay UniqueId="ListBox">
                             <ListBox MaxHeight="200"
                                      ItemsSource="{Binding SimpleContent}"
                                      SelectedItem="{Binding SelectedSimpleContent}" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="ComboBox">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="ComboBox">
                         <showMeTheXaml:XamlDisplay UniqueId="ComboBox">
                             <ComboBox ItemsSource="{Binding SimpleContent}" SelectedItem="{Binding SelectedSimpleContent}" />
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="AutoCompleteBox">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="AutoCompleteBox">
                         <showMeTheXaml:XamlDisplay UniqueId="AutoCompleteBox">
                             <AutoCompleteBox>
                                 <AutoCompleteBox.ItemsSource>
@@ -62,10 +62,10 @@
                                 </AutoCompleteBox.ItemsSource>
                             </AutoCompleteBox>
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="DataGrid">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="DataGrid">
                         <StackPanel>
                             <showMeTheXaml:XamlDisplay UniqueId="DataGrid">
                                 <DataGrid MinWidth="350"
@@ -90,10 +90,10 @@
                                            Text="Resizable Columns" />
                             </DockPanel>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Tree View">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Tree View">
                         <showMeTheXaml:XamlDisplay UniqueId="TreeView">
                             <TreeView MaxHeight="200" ItemsSource="{Binding TreeViewContent}">
                                 <TreeView.ItemTemplate>
@@ -103,8 +103,8 @@
                                 </TreeView.ItemTemplate>
                             </TreeView>
                         </showMeTheXaml:XamlDisplay>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/Colors/ColorsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Colors/ColorsView.axaml
@@ -2,7 +2,7 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:colors="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Colors"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
@@ -11,22 +11,22 @@
              x:DataType="colors:ColorsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Colors">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Colors">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>Below is a full list of all defined colors that are available either via XAML (DynamicResource) or via Application.Resources.</TextBlock>
                     <TextBlock>Click on any of the colors to copy it's name to your clipboard.</TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding Colors}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate>
-                        <controls:GlassCard Margin="15"
-                                            IsInteractive="True"
-                                            PointerPressed="InputElement_OnPointerPressed">
-                            <controls:GroupBox Header="{Binding Name}">
+                        <suki:GlassCard Margin="15"
+                                        IsInteractive="True"
+                                        PointerPressed="InputElement_OnPointerPressed">
+                            <suki:GroupBox Header="{Binding Name}">
                                 <Rectangle Width="50"
                                            Height="50"
                                            Margin="0,7,0,0"
@@ -43,8 +43,8 @@
                                         </Transitions>
                                     </Rectangle.Transitions>
                                 </Rectangle>
-                            </controls:GroupBox>
-                        </controls:GlassCard>
+                            </suki:GroupBox>
+                        </suki:GlassCard>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
                 <ItemsControl.ItemsPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ContextMenusView.axaml
@@ -1,8 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ContextMenusView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:content="clr-namespace:SukiUI.Content;assembly=SukiUI"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,10 +9,10 @@
              d:DesignWidth="800"
              x:DataType="controlsLibrary:ContextMenusViewModel"
              mc:Ignorable="d">
-    <controls:GlassCard HorizontalAlignment="Center"
-                        VerticalAlignment="Center"
-                        IsInteractive="True">
-        <controls:GlassCard.ContextMenu>
+    <suki:GlassCard HorizontalAlignment="Center"
+                    VerticalAlignment="Center"
+                    IsInteractive="True">
+        <suki:GlassCard.ContextMenu>
             <ContextMenu>
                 <!--  Ignore your IDE, x:False is a valid intrinsic  -->
                 <MenuItem Command="{Binding OptionClickedCommand}"
@@ -27,14 +26,14 @@
                     <MenuItem.Icon>
                         <PathIcon Width="15"
                                   Height="15"
-                                  Data="{x:Static content:Icons.Star}" />
+                                  Data="{x:Static suki:Icons.Star}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Disabled With Icon" IsEnabled="False">
                     <MenuItem.Icon>
                         <PathIcon Width="13"
                                   Height="13"
-                                  Data="{x:Static content:Icons.Cross}" />
+                                  Data="{x:Static suki:Icons.Cross}" />
                     </MenuItem.Icon>
                 </MenuItem>
                 <MenuItem Header="Separator Next" />
@@ -46,13 +45,13 @@
                     </MenuItem>
                 </MenuItem>
             </ContextMenu>
-        </controls:GlassCard.ContextMenu>
-        <controls:GroupBox Header="Context Menu Demo">
+        </suki:GlassCard.ContextMenu>
+        <suki:GroupBox Header="Context Menu Demo">
             <TextBlock HorizontalAlignment="Center"
                        VerticalAlignment="Center"
                        Classes="h3">
                 Right click anywhere in this card to open a context menu.
             </TextBlock>
-        </controls:GroupBox>
-    </controls:GlassCard>
+        </suki:GroupBox>
+    </suki:GlassCard>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogWindowDemo.axaml
@@ -1,42 +1,42 @@
-<controls:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.DialogWindowDemo"
-                     xmlns="https://github.com/avaloniaui"
-                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                     xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                     Title="Dialog Window Demo"
-                     Width="550"
-                     Height="400"
-                     d:DesignHeight="450"
-                     d:DesignWidth="800"
-                     mc:Ignorable="d">
+<suki:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.DialogWindowDemo"
+                 xmlns="https://github.com/avaloniaui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:suki="https://github.com/kikipoulet/SukiUI"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 Title="Dialog Window Demo"
+                 Width="550"
+                 Height="400"
+                 d:DesignHeight="450"
+                 d:DesignWidth="800"
+                 mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Toasts">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Toasts">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         Demos the ability for individual windows (or the main window) to be addressed by the dialog system.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Show In This Window">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Show In This Window">
                         <Button Margin="15,10,15,0"
                                 Click="ShowDialogInThisWindowClicked"
                                 Content="Show Dialog" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Show In MainWindow">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Show In MainWindow">
                         <Button Margin="15,10,15,0"
                                 Click="ShowDialogInMainWindowClicked"
                                 Content="Show Dialog" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>
-</controls:SukiWindow>
+</suki:SukiWindow>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/DialogsView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.DialogsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dialogs="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Dialogs"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,8 +10,8 @@
              x:DataType="dialogs:DialogsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Dialogs">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Dialogs">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI provides a rich dialog experience out of the box, allowing the display of any arbitrary control, view or ViewModel (with suitable ViewLocator defined) as a dialog.
@@ -25,38 +25,38 @@
                         Click any of the following buttons to open up a dialog.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Standard Dialog">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Standard Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenStandardDialogCommand}"
                                 Content="Show Dialog" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Background Closable Dialog">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Background Closable Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenBackgroundCloseDialogCommand}"
                                 Content="Show Dialog" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="ViewModel Dialog">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="ViewModel Dialog">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenViewModelDialogCommand}"
                                 Content="Show Dialog" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Window Dialog Demo">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Window Dialog Demo">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding OpenDialogWindowDemoCommand}"
                                 Content="Open" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Dialogs/VmDialogView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.Dialogs.VmDialogView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dialogs="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Dialogs"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -9,7 +9,7 @@
              d:DesignWidth="800"
              x:DataType="dialogs:VmDialogViewModel"
              mc:Ignorable="d">
-    <controls:GroupBox Header="A ViewModel Dialog">
+    <suki:GroupBox Header="A ViewModel Dialog">
         <StackPanel Classes="HeaderContent">
             <TextBlock>
                 This dialog was created by passing a ViewModel to the dialog system.
@@ -23,5 +23,5 @@
                     Command="{Binding CloseDialogCommand}"
                     Content="Close" />
         </StackPanel>
-    </controls:GroupBox>
+    </suki:GroupBox>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/DockControls/ErrorList.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/DockControls/ErrorList.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SukiUI.Demo.Features.ControlsLibrary.DockControls.ErrorList">
@@ -10,27 +10,27 @@
         <StackPanel Margin="15,15">
             <StackPanel Orientation="Horizontal" Spacing="12">
       
-                <controls:GlassCard CornerRadius="10" Padding="12,8">
+                <suki:GlassCard CornerRadius="10" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <avalonia:MaterialIcon Kind="Error" Foreground="Red" Width="16" Height="16" />
                         <TextBlock FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}" Text="2 Errors"></TextBlock>
                     </StackPanel>
      
-                </controls:GlassCard>
-                <controls:GlassCard CornerRadius="10" Padding="12,8">
+                </suki:GlassCard>
+                <suki:GlassCard CornerRadius="10" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <avalonia:MaterialIcon Kind="WarningCircle" Foreground="Orange" Width="16" Height="16" />
                         <TextBlock FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}" Text="2 Warnings"></TextBlock>
                     </StackPanel>
      
-                </controls:GlassCard>
-                <controls:GlassCard CornerRadius="10" Padding="12,8">
+                </suki:GlassCard>
+                <suki:GlassCard CornerRadius="10" Padding="12,8">
                     <StackPanel Orientation="Horizontal" Spacing="8">
                         <avalonia:MaterialIcon Kind="InformationCircle" Foreground="{DynamicResource SukiPrimaryColor}" Width="16" Height="16" />
                         <TextBlock FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}" Text="0 Messages"></TextBlock>
                     </StackPanel>
      
-                </controls:GlassCard>
+                </suki:GlassCard>
             </StackPanel>
     
             <DataGrid Name="DG" Margin="0,10" AutoGenerateColumns="True"></DataGrid>

--- a/SukiUI.Demo/Features/ControlsLibrary/DockControls/propertiesview.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/DockControls/propertiesview.axaml
@@ -2,7 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              mc:Ignorable="d" d:DesignWidth="800" d:DesignHeight="450"
              x:Class="SukiUI.Demo.Features.ControlsLibrary.DockControls.propertiesview">
      <StackPanel Margin="15,25,15,0" >
@@ -14,11 +14,11 @@
        </Panel>
        <Panel>
          <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="Height" FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}"></TextBlock>
-         <NumericUpDown VerticalAlignment="Center" HorizontalAlignment="Right" Value="800" theme:NumericUpDownExtensions.Unit="px" ShowButtonSpinner="False"></NumericUpDown>
+         <NumericUpDown VerticalAlignment="Center" HorizontalAlignment="Right" Value="800" suki:NumericUpDownExtensions.Unit="px" ShowButtonSpinner="False"></NumericUpDown>
        </Panel>
        <Panel>
          <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="Width" FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}"></TextBlock>
-         <NumericUpDown VerticalAlignment="Center" HorizontalAlignment="Right" Value="1200" theme:NumericUpDownExtensions.Unit="px" ShowButtonSpinner="False"></NumericUpDown>
+         <NumericUpDown VerticalAlignment="Center" HorizontalAlignment="Right" Value="1200" suki:NumericUpDownExtensions.Unit="px" ShowButtonSpinner="False"></NumericUpDown>
        </Panel>
        <Panel>
          <TextBlock VerticalAlignment="Center" HorizontalAlignment="Left" Text="Maximized" FontWeight="DemiBold" Foreground="{DynamicResource SukiLowText}"></TextBlock>

--- a/SukiUI.Demo/Features/ControlsLibrary/ExpanderView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ExpanderView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ExpanderView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,37 +10,37 @@
              x:DataType="controlsLibrary:ExpanderViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto, *">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Expander">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Expander">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         Expanders have styles for all ExpandDirections, using custom animation behaviour and controls internally to correctly animate showing/hiding any size content.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
+                <suki:GlassCard>
                     <Expander ExpandDirection="Down" Header="Down Expander">
                         <TextBlock>Some Down Content</TextBlock>
                     </Expander>
-                </controls:GlassCard>
-                <controls:GlassCard>
+                </suki:GlassCard>
+                <suki:GlassCard>
                     <Expander ExpandDirection="Up" Header="Up Expander">
                         <TextBlock>Some Up Content</TextBlock>
                     </Expander>
-                </controls:GlassCard>
-                <controls:GlassCard>
+                </suki:GlassCard>
+                <suki:GlassCard>
                     <Expander ExpandDirection="Right" Header="Right Expander">
                         <TextBlock>Some Right Content</TextBlock>
                     </Expander>
-                </controls:GlassCard>
-                <controls:GlassCard>
+                </suki:GlassCard>
+                <suki:GlassCard>
                     <Expander ExpandDirection="Left" Header="Left Expander">
                         <TextBlock>Some Left Content</TextBlock>
                     </Expander>
-                </controls:GlassCard>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/IconsView.axaml
@@ -1,20 +1,18 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.IconsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:content="clr-namespace:SukiUI.Content;assembly=SukiUI"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:IconsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto, *">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Icons">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Icons">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock TextWrapping="Wrap">
                         SukiUI contains definitions for some basic icons that are used for a variety of controls. You may wish to use these icons in your app and controls to maintain consistency with SukiUI.
@@ -24,35 +22,35 @@
                     </TextBlock>
                     <StackPanel Orientation="Horizontal" Spacing="15">
                         <showMeTheXaml:XamlDisplay UniqueId="Icon1">
-                            <PathIcon Data="{x:Static content:Icons.Plus}" />
+                            <PathIcon Data="{x:Static suki:Icons.Plus}" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="Icon2">
-                            <PathIcon Classes="Primary" Data="{x:Static content:Icons.Plus}" />
+                            <PathIcon Classes="Primary" Data="{x:Static suki:Icons.Plus}" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="Icon3">
-                            <PathIcon Classes="Accent" Data="{x:Static content:Icons.Plus}" />
+                            <PathIcon Classes="Accent" Data="{x:Static suki:Icons.Plus}" />
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
                     <TextBlock>
                         Here is the full list of available icons, click on any of them to copy the XAML to use it to the clipboard:
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
-            <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding AllIcons}">
+            <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding AllIcons}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:CompileBindings="False">
-                        <controls:GlassCard Margin="15,15,15,15"
-                                            IsInteractive="True"
-                                            PointerPressed="InputElement_OnPointerPressed">
-                            <controls:GroupBox Header="{Binding Key}">
+                        <suki:GlassCard Margin="15,15,15,15"
+                                        IsInteractive="True"
+                                        PointerPressed="InputElement_OnPointerPressed">
+                            <suki:GroupBox Header="{Binding Key}">
                                 <PathIcon Width="25"
                                           Height="25"
                                           Margin="0,8,0,0"
                                           Data="{Binding Value}" />
-                            </controls:GroupBox>
-                        </controls:GlassCard>
+                            </suki:GroupBox>
+                        </suki:GlassCard>
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
                 <ItemsControl.ItemsPanel>

--- a/SukiUI.Demo/Features/ControlsLibrary/InfoBarView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/InfoBarView.axaml
@@ -1,7 +1,7 @@
 ﻿<UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.InfoBarView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -10,8 +10,8 @@
              x:DataType="controlsLibrary:InfoBarViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto, *">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="InfoBar">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="InfoBar">
                 <StackPanel Classes="HeaderContent" Spacing="15">
                     <TextBlock>
                         InfoBar is a control that displays a message to the user. It can be used to show specific severity message to the user.
@@ -51,37 +51,37 @@
                         <ToggleSwitch Margin="15,0,0,0" IsChecked="{Binding IsOpaque}" />
                     </StackPanel>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
+                <suki:GlassCard>
                     <StackPanel Spacing="7">
-                        <controls:InfoBar Title="Info" IsOpaque="{Binding IsOpaque}"
-                                          Margin="10"
-                                          IsClosable="{Binding IsClosable}"
-                                          IsOpen="{Binding IsOpen, Mode=TwoWay}"
-                                          Message="{Binding #MessageTextBox.Text}" />
-                        <controls:InfoBar Title="Warning"  IsOpaque="{Binding IsOpaque}"
-                                          Margin="10"
-                                          IsClosable="{Binding IsClosable}"
-                                          IsOpen="{Binding IsOpen, Mode=TwoWay}"
-                                          Message="{Binding #MessageTextBox.Text}"
-                                          Severity="Warning" />
-                        <controls:InfoBar Title="Error"  IsOpaque="{Binding IsOpaque}"
-                                          Margin="10"
-                                          IsClosable="{Binding IsClosable}"
-                                          IsOpen="{Binding IsOpen, Mode=TwoWay}"
-                                          Message="{Binding #MessageTextBox.Text}"
-                                          Severity="Error" />
-                        <controls:InfoBar Title="Success"
-                                          Margin="10"  IsOpaque="{Binding IsOpaque}"
-                                          IsClosable="{Binding IsClosable}"
-                                          IsOpen="{Binding IsOpen, Mode=TwoWay}"
-                                          Message="{Binding #MessageTextBox.Text}"
-                                          Severity="Success" />
+                        <suki:InfoBar Title="Info" IsOpaque="{Binding IsOpaque}"
+                                      Margin="10"
+                                      IsClosable="{Binding IsClosable}"
+                                      IsOpen="{Binding IsOpen, Mode=TwoWay}"
+                                      Message="{Binding #MessageTextBox.Text}" />
+                        <suki:InfoBar Title="Warning"  IsOpaque="{Binding IsOpaque}"
+                                      Margin="10"
+                                      IsClosable="{Binding IsClosable}"
+                                      IsOpen="{Binding IsOpen, Mode=TwoWay}"
+                                      Message="{Binding #MessageTextBox.Text}"
+                                      Severity="Warning" />
+                        <suki:InfoBar Title="Error"  IsOpaque="{Binding IsOpaque}"
+                                      Margin="10"
+                                      IsClosable="{Binding IsClosable}"
+                                      IsOpen="{Binding IsOpen, Mode=TwoWay}"
+                                      Message="{Binding #MessageTextBox.Text}"
+                                      Severity="Error" />
+                        <suki:InfoBar Title="Success"
+                                      Margin="10"  IsOpaque="{Binding IsOpaque}"
+                                      IsClosable="{Binding IsClosable}"
+                                      IsOpen="{Binding IsOpen, Mode=TwoWay}"
+                                      Message="{Binding #MessageTextBox.Text}"
+                                      Severity="Success" />
                     </StackPanel>
-                </controls:GlassCard>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/MiscView.axaml
@@ -1,79 +1,78 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.MiscView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:MiscViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Miscellaneous">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Miscellaneous">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         An assortment of controls that don't otherwise fit neatly into another category.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard MaxWidth="300">
-                    <controls:BusyArea BusyText="Busy..." IsBusy="{Binding IsBusy}">
-                        <controls:GroupBox Header="Busy Area">
+                <suki:GlassCard MaxWidth="300">
+                    <suki:BusyArea BusyText="Busy..." IsBusy="{Binding IsBusy}">
+                        <suki:GroupBox Header="Busy Area">
                             <StackPanel Spacing="10">
                                 <TextBlock Classes="h3" TextWrapping="Wrap">Click this button to set the card area busy for 3 seconds.</TextBlock>
                                 <Button HorizontalAlignment="Center"
                                         Command="{Binding ToggleBusyCommand}"
                                         Content="Click Me." />
                             </StackPanel>
-                        </controls:GroupBox>
-                    </controls:BusyArea>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Date Picker">
+                        </suki:GroupBox>
+                    </suki:BusyArea>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Date Picker">
                         <StackPanel Spacing="15">
                             <DatePicker SelectedDate="{Binding SelectedDateTimeOffset}" />
                             <CalendarDatePicker SelectedDate="{Binding SelectedDateTimeOffset}" />
                         </StackPanel>
 
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Calendar">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Calendar">
                         <Calendar SelectedDate="{Binding SelectedDateTime}" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Time Picker">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Time Picker">
                         <TimePicker />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Numeric Up/Down">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Numeric Up/Down">
                         <StackPanel Spacing="10">
                             <showMeTheXaml:XamlDisplay UniqueId="Numeric1">
                                 <NumericUpDown Value="10" />
                             </showMeTheXaml:XamlDisplay>
                             <showMeTheXaml:XamlDisplay UniqueId="Numeric2">
-                                <NumericUpDown theme:NumericUpDownExtensions.Unit="inch" Value="10" />
+                                <NumericUpDown suki:NumericUpDownExtensions.Unit="inch" Value="10" />
                             </showMeTheXaml:XamlDisplay>
                             <showMeTheXaml:XamlDisplay UniqueId="Numeric3">
-                                <NumericUpDown theme:NumericUpDownExtensions.Unit="inch"
+                                <NumericUpDown suki:NumericUpDownExtensions.Unit="inch"
                                                ShowButtonSpinner="False"
                                                Value="10" />
                             </showMeTheXaml:XamlDisplay>
 
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="DropDownButton">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="DropDownButton">
                         <DropDownButton Content="Click To Open">
                             <DropDownButton.Flyout>
                                 <Flyout>
@@ -87,11 +86,11 @@
                                 </Flyout>
                             </DropDownButton.Flyout>
                         </DropDownButton>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="File Picker">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="File Picker">
                         <StackPanel Spacing="8">
                             <Button Margin="5"
                                     HorizontalAlignment="Center"
@@ -112,11 +111,11 @@
                                     Command="{Binding OpenFolderCommand}"
                                     Content="Open Folder" />
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
                 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Message Box">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Message Box">
                         <StackPanel Spacing="8">
                             <Button Margin="5"
                                     HorizontalAlignment="Center"
@@ -133,8 +132,8 @@
                                     Content="Open Error MessageBox" />
                             
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/ProgressView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.ProgressView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controls1="clr-namespace:SukiUI.Demo.Controls"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
@@ -12,8 +12,8 @@
              x:DataType="controlsLibrary:ProgressViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Progress Indicators">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Progress Indicators">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         Here is a demo of all the available progress indicators in SukiUI, including the stepper.
@@ -56,60 +56,60 @@
                                    Text="{Binding ProgressValue}" />
                     </StackPanel>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1" HorizontalScrollBarVisibility="Disabled">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard Margin="20">
-                    <controls:GroupBox Header="Wave Progress">
+                <suki:GlassCard Margin="20">
+                    <suki:GroupBox Header="Wave Progress">
                         <Grid>
                             <showMeTheXaml:XamlDisplay VerticalAlignment="Center" UniqueId="WaveProgress">
-                                <controls:WaveProgress IsTextVisible="{Binding IsTextVisible}" Value="{Binding ProgressValue}" />
+                                <suki:WaveProgress IsTextVisible="{Binding IsTextVisible}" Value="{Binding ProgressValue}" />
                             </showMeTheXaml:XamlDisplay>
                         </Grid>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Circle Progress">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Circle Progress">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="CircleProgress1">
-                                <controls:CircleProgressBar Width="130"
-                                                            Height="130"
-                                                            IsIndeterminate="{Binding IsIndeterminate}"
-                                                            StrokeWidth="11"
-                                                            Value="{Binding ProgressValue}">
+                                <suki:CircleProgressBar Width="130"
+                                                        Height="130"
+                                                        IsIndeterminate="{Binding IsIndeterminate}"
+                                                        StrokeWidth="11"
+                                                        Value="{Binding ProgressValue}">
                                     <TextBlock Margin="0,2,0,0"
                                                Classes="h3"
                                                IsVisible="{Binding IsTextVisible}"
                                                Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
-                                </controls:CircleProgressBar>
+                                </suki:CircleProgressBar>
                             </showMeTheXaml:XamlDisplay>
                             <showMeTheXaml:XamlDisplay UniqueId="CircleProgress2">
-                                <controls:CircleProgressBar Width="130"
-                                                            Height="130"
-                                                            Classes="Accent"
-                                                            IsIndeterminate="{Binding IsIndeterminate}"
-                                                            StrokeWidth="11"
-                                                            Value="{Binding ProgressValue}">
+                                <suki:CircleProgressBar Width="130"
+                                                        Height="130"
+                                                        Classes="Accent"
+                                                        IsIndeterminate="{Binding IsIndeterminate}"
+                                                        StrokeWidth="11"
+                                                        Value="{Binding ProgressValue}">
                                     <TextBlock Margin="0,2,0,0"
                                                Classes="h3"
                                                IsVisible="{Binding IsTextVisible}"
                                                Text="{Binding ProgressValue, StringFormat={}{0:#0}%}" />
-                                </controls:CircleProgressBar>
+                                </suki:CircleProgressBar>
                             </showMeTheXaml:XamlDisplay>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard Width="400">
-                    <controls:GroupBox Header="Standard Progress Bar">
-                        <controls:GroupBox.Styles>
+                <suki:GlassCard Width="400">
+                    <suki:GroupBox Header="Standard Progress Bar">
+                        <suki:GroupBox.Styles>
                             <Style Selector="ProgressBar">
                                 <Setter Property="Value" Value="{Binding ProgressValue}" />
                                 <Setter Property="ShowProgressText" Value="{Binding IsTextVisible}" />
                             </Style>
-                        </controls:GroupBox.Styles>
+                        </suki:GroupBox.Styles>
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="Progress1">
                                 <ProgressBar IsIndeterminate="{Binding IsIndeterminate}" />
@@ -130,25 +130,25 @@
                                 </showMeTheXaml:XamlDisplay>
                             </StackPanel>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Loading Indicator">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Loading Indicator">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="Loading1">
-                                <controls:Loading />
+                                <suki:Loading />
                             </showMeTheXaml:XamlDisplay>
                             <showMeTheXaml:XamlDisplay UniqueId="Loading2">
-                                <controls:Loading Classes="Accent" />
+                                <suki:Loading Classes="Accent" />
                             </showMeTheXaml:XamlDisplay>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
 
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Custom Loading Indicators">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Custom Loading Indicators">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="Loading3">
                                 <controls1:LoadingTest />
@@ -157,14 +157,14 @@
                                 <controls1:LoadingTest LoadingStyle="Pellets" />
                             </showMeTheXaml:XamlDisplay>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard Width="500">
-                    <controls:GroupBox Header="Stepper">
+                <suki:GlassCard Width="500">
+                    <suki:GroupBox Header="Stepper">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay Margin="0,20,0,0" UniqueId="Stepper">
-                                <controls:Stepper Index="{Binding StepIndex}" Steps="{Binding Steps}" />
+                                <suki:Stepper Index="{Binding StepIndex}" Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
                             <!--  Ignore your IDE, x:True and x:False are absolutely valid intrinsics in Avalonia.  -->
                             <Grid Margin="0,18,0,0" ColumnDefinitions="Auto,*,Auto">
@@ -178,16 +178,16 @@
                                         Content="Increment" />
                             </Grid>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
 
-                <controls:GlassCard Width="500">
-                    <controls:GroupBox Header="Alternative Stepper">
+                <suki:GlassCard Width="500">
+                    <suki:GroupBox Header="Alternative Stepper">
                         <StackPanel Spacing="15">
                             <showMeTheXaml:XamlDisplay UniqueId="AltStepper">
-                                <controls:Stepper AlternativeStyle="True"
-                                                  Index="{Binding StepIndex}"
-                                                  Steps="{Binding Steps}" />
+                                <suki:Stepper AlternativeStyle="True"
+                                              Index="{Binding StepIndex}"
+                                              Steps="{Binding Steps}" />
                             </showMeTheXaml:XamlDisplay>
                             <!--  Ignore your IDE, x:True and x:False are absolutely valid intrinsics in Avalonia.  -->
                             <Grid ColumnDefinitions="Auto,*,Auto">
@@ -201,8 +201,8 @@
                                         Content="Increment" />
                             </Grid>
                         </StackPanel>
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/PropertyGridView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/PropertyGridView.axaml
@@ -1,33 +1,32 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.PropertyGridView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="1050"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:PropertyGridViewModel"
              mc:Ignorable="d">
 
     <WrapPanel Classes="PageContainer" Orientation="Horizontal">
-        <controls:GlassCard Width="500">
+        <suki:GlassCard Width="500">
             <ScrollViewer>
-                <controls:PropertyGrid Item="{Binding Form}">
-                    <controls:PropertyGrid.DataTemplates>
+                <suki:PropertyGrid Item="{Binding Form}">
+                    <suki:PropertyGrid.DataTemplates>
                         <!--
                             replace the PropertyGridTemplateSelector with your own type or subclass it,
                             if you want to customize the dataTemplates being used
                         -->
-                        <controls:PropertyGridTemplateSelector UseSukiHost="False" />
-                    </controls:PropertyGrid.DataTemplates>
-                </controls:PropertyGrid>
+                        <suki:PropertyGridTemplateSelector UseSukiHost="False" />
+                    </suki:PropertyGrid.DataTemplates>
+                </suki:PropertyGrid>
             </ScrollViewer>
-        </controls:GlassCard>
+        </suki:GlassCard>
 
-        <controls:GlassCard Width="400">
-            <controls:GroupBox Header="Form Output">
+        <suki:GlassCard Width="400">
+            <suki:GroupBox Header="Form Output">
                 <ScrollViewer>
                     <ScrollViewer.Styles>
                         <Style Selector="TextBox">
@@ -35,23 +34,23 @@
                         </Style>
                     </ScrollViewer.Styles>
                     <StackPanel DataContext="{Binding Form}" Orientation="Vertical">
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableName:  " Text="{Binding NullableName}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableDescription:  " Text="{Binding NullableDescription}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableBoolean:  " Text="{Binding NullableBoolean}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableDateTime:  " Text="{Binding NullableDateTime}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableInteger:  " Text="{Binding NullableInteger}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableLong:  " Text="{Binding NullableLong}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableDecimal:  " Text="{Binding NullableDecimal}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableFloat:  " Text="{Binding NullableFloat}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="NullableDouble:  " Text="{Binding NullableDouble}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="Name:  " Text="{Binding Name}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="Integer:  " Text="{Binding Integer}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="Decimal:  " Text="{Binding Decimal}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="Boolean:  " Text="{Binding Boolean}" />
-                        <TextBox theme:TextBoxExtensions.Prefix="DateTime:  " Text="{Binding DateTime}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableName:  " Text="{Binding NullableName}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableDescription:  " Text="{Binding NullableDescription}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableBoolean:  " Text="{Binding NullableBoolean}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableDateTime:  " Text="{Binding NullableDateTime}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableInteger:  " Text="{Binding NullableInteger}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableLong:  " Text="{Binding NullableLong}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableDecimal:  " Text="{Binding NullableDecimal}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableFloat:  " Text="{Binding NullableFloat}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="NullableDouble:  " Text="{Binding NullableDouble}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="Name:  " Text="{Binding Name}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="Integer:  " Text="{Binding Integer}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="Decimal:  " Text="{Binding Decimal}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="Boolean:  " Text="{Binding Boolean}" />
+                        <TextBox suki:TextBoxExtensions.Prefix="DateTime:  " Text="{Binding DateTime}" />
                     </StackPanel>
                 </ScrollViewer>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
     </WrapPanel>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/StackPage/RecursiveView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/StackPage/RecursiveView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.StackPage.RecursiveView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:stackPage="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.StackPage"
@@ -9,12 +9,12 @@
              d:DesignWidth="800"
              x:DataType="stackPage:RecursiveViewModel"
              mc:Ignorable="d">
-    <controls:GlassCard HorizontalAlignment="Center" VerticalAlignment="Center">
-        <controls:GroupBox Header="{Binding Title}">
+    <suki:GlassCard HorizontalAlignment="Center" VerticalAlignment="Center">
+        <suki:GroupBox Header="{Binding Title}">
             <StackPanel Spacing="10">
                 <TextBlock>This is a recursive viewmodel, click the button to go deeper.</TextBlock>
                 <Button Command="{Binding RecurseCommand}" Content="Click Me" />
             </StackPanel>
-        </controls:GroupBox>
-    </controls:GlassCard>
+        </suki:GroupBox>
+    </suki:GlassCard>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/StackPage/StackPageView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/StackPage/StackPageView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.StackPage.StackPageView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:stackPage="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.StackPage"
@@ -10,8 +10,8 @@
              x:DataType="stackPage:StackPageViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto, *">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="StackPage">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="StackPage">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI provides a simple StackPage implementation in the form of SukiStackPage.
@@ -41,10 +41,10 @@
                         <TextBlock VerticalAlignment="Center" FontWeight="DemiBold" Text="{Binding Limit}" />
                     </DockPanel>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
-        <controls:SukiStackPage Grid.Row="1"
-                                Content="{Binding ActiveVm}"
-                                Limit="{Binding Limit}" />
+            </suki:GroupBox>
+        </suki:GlassCard>
+        <suki:SukiStackPage Grid.Row="1"
+                            Content="{Binding ActiveVm}"
+                            Limit="{Binding Limit}" />
     </Grid>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/TabControl/TabControlView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TabControl/TabControlView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.TabControl.TabControlView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:tabControl="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.TabControl"
@@ -31,8 +31,8 @@
         </Style>
     </UserControl.Styles>
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Tab Controls">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Tab Controls">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         Styles are available for all TabStripPlacements.
@@ -41,30 +41,30 @@
                         Tab 6 is disabled for demonstration purposes.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Standard Tab Control">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Standard Tab Control">
                         <TabControl />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Left Tab Control">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Left Tab Control">
                         <TabControl TabStripPlacement="Left" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Right Tab Control">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Right Tab Control">
                         <TabControl TabStripPlacement="Right" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Bottom Tab Control">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Bottom Tab Control">
                         <TabControl TabStripPlacement="Bottom" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TextView.axaml
@@ -1,12 +1,11 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.TextView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:showMeTheXaml="clr-namespace:ShowMeTheXaml;assembly=ShowMeTheXaml.Avalonia"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="controlsLibrary:TextViewModel"
@@ -22,8 +21,8 @@
     </UserControl.Styles>
     <ScrollViewer HorizontalScrollBarVisibility="Disabled">
         <WrapPanel Classes="PageContainer">
-            <controls:GlassCard>
-                <controls:GroupBox Header="Text Styles">
+            <suki:GlassCard>
+                <suki:GroupBox Header="Text Styles">
                     <StackPanel Spacing="15">
                         <StackPanel Classes="HeaderContent">
                             <TextBlock>
@@ -62,10 +61,10 @@
                         </showMeTheXaml:XamlDisplay>
                         <TextBox Text="{Binding TextBlockValue}" />
                     </StackPanel>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="Text Input">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="Text Input">
                     <StackPanel Classes="HeaderContent">
                        
                         <TextBlock>
@@ -78,17 +77,17 @@
                             <TextBox Text="" Watermark="Watermark" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="TextBox3">
-                            <TextBox theme:TextBoxExtensions.Prefix="https://" />
+                            <TextBox suki:TextBoxExtensions.Prefix="https://" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="TextBox4">
                             <TextBox PasswordChar="*" />
                         </showMeTheXaml:XamlDisplay>
                         <showMeTheXaml:XamlDisplay UniqueId="TextBox5">
-                            <TextBox theme:TextBoxExtensions.AddDeleteButton="True" />
+                            <TextBox suki:TextBoxExtensions.AddDeleteButton="True" />
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
-                </controls:GroupBox>
-            </controls:GlassCard>
+                </suki:GroupBox>
+            </suki:GlassCard>
         </WrapPanel>
     </ScrollViewer>
 </UserControl>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastWindowDemo.axaml
@@ -1,42 +1,42 @@
-<controls:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastWindowDemo"
-                     xmlns="https://github.com/avaloniaui"
-                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                     xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-                     xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
-                     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                     Title="Toast Window Demo"
-                     Width="550"
-                     Height="400"
-                     d:DesignHeight="450"
-                     d:DesignWidth="800"
-                     mc:Ignorable="d">
+<suki:SukiWindow x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastWindowDemo"
+                 xmlns="https://github.com/avaloniaui"
+                 xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                 xmlns:suki="https://github.com/kikipoulet/SukiUI"
+                 xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+                 xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+                 Title="Toast Window Demo"
+                 Width="550"
+                 Height="400"
+                 d:DesignHeight="450"
+                 d:DesignWidth="800"
+                 mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Toasts">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Toasts">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         Demos the ability for individual windows (or the main window) to be addressed by the toast system.
                     </TextBlock>
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Show In This Window">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Show In This Window">
                         <Button Margin="15,10,15,0"
                                 Click="ShowToastInThisWindowClicked"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Show In MainWindow">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Show In MainWindow">
                         <Button Margin="15,10,15,0"
                                 Click="ShowToastInMainWindowClicked"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>
-</controls:SukiWindow>
+</suki:SukiWindow>

--- a/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.Toasts.ToastsView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:toasts="clr-namespace:SukiUI.Demo.Features.ControlsLibrary.Toasts"
@@ -10,8 +10,8 @@
              x:DataType="toasts:ToastsViewModel"
              mc:Ignorable="d">
     <Grid RowDefinitions="Auto,*">
-        <controls:GlassCard Classes="HeaderCard">
-            <controls:GroupBox Header="Toasts">
+        <suki:GlassCard Classes="HeaderCard">
+            <suki:GroupBox Header="Toasts">
                 <StackPanel Classes="HeaderContent">
                     <TextBlock>
                         SukiUI contains an API for creating and dismissing 4 kinds of toasts, with the ability to set limits on the number of toasts.
@@ -32,66 +32,66 @@
                         NavigateUri="https://github.com/kikipoulet/SukiUI/blob/main/SukiUI.Demo/Features/ControlsLibrary/Toasts/ToastsViewModel.cs"
                         Content="Source Here." />
                 </StackPanel>
-            </controls:GroupBox>
-        </controls:GlassCard>
+            </suki:GroupBox>
+        </suki:GlassCard>
         <ScrollViewer Grid.Row="1">
             <WrapPanel Classes="PageContainer">
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Info Toast">
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Info Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowInfoToastCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Success Toast">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Success Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowSuccessToastCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Warning Toast">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Warning Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowWarningToastCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Error Toast">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Error Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowErrorToastCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="3 Info Toasts">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="3 Info Toasts">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowThreeInfoToastsCommand}"
                                 Content="Show Toasts" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Callback Toast">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Callback Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowToastWithCallbackCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Action Toast">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Action Toast">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowActionToastCommand}"
                                 Content="Show Toast" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
-                <controls:GlassCard>
-                    <controls:GroupBox Header="Separate Toast Window">
+                    </suki:GroupBox>
+                </suki:GlassCard>
+                <suki:GlassCard>
+                    <suki:GroupBox Header="Separate Toast Window">
                         <Button Margin="15,10,15,0"
                                 Command="{Binding ShowToastWindowCommand}"
                                 Content="Open" />
-                    </controls:GroupBox>
-                </controls:GlassCard>
+                    </suki:GroupBox>
+                </suki:GlassCard>
             </WrapPanel>
         </ScrollViewer>
     </Grid>

--- a/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
+++ b/SukiUI.Demo/Features/ControlsLibrary/TogglesView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.ControlsLibrary.TogglesView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:controlsLibrary="clr-namespace:SukiUI.Demo.Features.ControlsLibrary"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -12,8 +12,8 @@
              mc:Ignorable="d">
     <ScrollViewer>
         <WrapPanel Classes="PageContainer">
-            <controls:GlassCard>
-                <controls:GroupBox Header="Radio Buttons">
+            <suki:GlassCard>
+                <suki:GroupBox Header="Radio Buttons">
                     <showMeTheXaml:XamlDisplay UniqueId="RadioButtons">
                         <StackPanel VerticalAlignment="Center" Spacing="10">
                             <RadioButton Content="Option One"
@@ -23,10 +23,10 @@
                             <RadioButton Content="Option Three" GroupName="R1" />
                         </StackPanel>
                     </showMeTheXaml:XamlDisplay>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="Simple GigaChips">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="Simple GigaChips">
                     <showMeTheXaml:XamlDisplay UniqueId="SimpleGigaChips">
                         <StackPanel>
                             <RadioButton Classes="GigaChips"
@@ -41,10 +41,10 @@
                                          GroupName="R2" />
                         </StackPanel>
                     </showMeTheXaml:XamlDisplay>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="Complex GigaChips">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="Complex GigaChips">
                     <showMeTheXaml:XamlDisplay UniqueId="ComplexGigaChips">
                         <StackPanel Orientation="Horizontal">
                             <RadioButton Classes="GigaChips"
@@ -81,10 +81,10 @@
                             </RadioButton>
                         </StackPanel>
                     </showMeTheXaml:XamlDisplay>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="Toggle Switches">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="Toggle Switches">
                     <StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="ToggleSwitch">
                             <ToggleSwitch IsChecked="True" />
@@ -93,10 +93,10 @@
                             <ToggleSwitch OffContent="Switch Off." OnContent="Switch On." />
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="Toggle Buttons">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="Toggle Buttons">
                     <StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="ToggleButton">
                             <ToggleButton Content="Toggle Me" />
@@ -108,10 +108,10 @@
                             <ToggleButton Classes="Switch" Content="Toggle Me" />
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
-                </controls:GroupBox>
-            </controls:GlassCard>
-            <controls:GlassCard>
-                <controls:GroupBox Header="CheckBoxes">
+                </suki:GroupBox>
+            </suki:GlassCard>
+            <suki:GlassCard>
+                <suki:GroupBox Header="CheckBoxes">
                     <StackPanel>
                         <showMeTheXaml:XamlDisplay UniqueId="CheckBox">
                             <StackPanel Spacing="5">
@@ -121,8 +121,8 @@
                             </StackPanel>
                         </showMeTheXaml:XamlDisplay>
                     </StackPanel>
-                </controls:GroupBox>
-            </controls:GlassCard>
+                </suki:GroupBox>
+            </suki:GlassCard>
         </WrapPanel>
     </ScrollViewer>
 </UserControl>

--- a/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogView.axaml
+++ b/SukiUI.Demo/Features/CustomTheme/CustomThemeDialogView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.CustomTheme.CustomThemeDialogView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:customTheme="clr-namespace:SukiUI.Demo.Features.CustomTheme"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -9,12 +9,12 @@
              d:DesignWidth="800"
              x:DataType="customTheme:CustomThemeDialogViewModel"
              mc:Ignorable="d">
-    <controls:GroupBox Header="Create Custom Theme">
+    <suki:GroupBox Header="Create Custom Theme">
         <StackPanel Spacing="20">
             <TextBox Text="{Binding DisplayName}" />
             <ColorPicker Color="{Binding PrimaryColor}" />
             <ColorPicker Color="{Binding AccentColor}" />
             <Button Command="{Binding TryCreateThemeCommand}" Content="Create" />
         </StackPanel>
-    </controls:GroupBox>
+    </suki:GroupBox>
 </UserControl>

--- a/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
+++ b/SukiUI.Demo/Features/Dashboard/DashboardView.axaml
@@ -5,8 +5,7 @@
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:dashboard="clr-namespace:SukiUI.Demo.Features.Dashboard"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="dashboard:DashboardViewModel"
@@ -15,7 +14,7 @@
     <ScrollViewer VerticalScrollBarVisibility="Hidden">
 
         <WrapPanel Margin="15"
-                   theme:WrapPanelExtensions.AnimatedScroll="True"
+                   suki:WrapPanelExtensions.AnimatedScroll="True"
                    Orientation="Horizontal">
 
             <!--  Login  -->
@@ -39,13 +38,13 @@
                             <TextBlock Margin="6,0,0,3"
                                        FontWeight="DemiBold"
                                        Text="Username" />
-                            <TextBox theme:TextBoxExtensions.Prefix="" Watermark="John" />
+                            <TextBox suki:TextBoxExtensions.Prefix="" Watermark="John" />
                             <TextBlock Margin="6,18,0,3"
                                        FontWeight="DemiBold"
                                        Text="Password" />
                             <TextBox Name="PasswordTextBox" Watermark="*******"
                                      Margin="0,0,0,25"
-                                     theme:TextBoxExtensions.AddDeleteButton="False"
+                                     suki:TextBoxExtensions.AddDeleteButton="False"
                                      PasswordChar="*" />
                         </StackPanel>
                     </suki:BusyArea>
@@ -56,7 +55,7 @@
                         Margin="0,0,0,7"
                         HorizontalAlignment="Center"
                         VerticalAlignment="Bottom"
-                        theme:ButtonExtensions.ShowProgress="{Binding IsLoggingIn}"
+                        suki:ButtonExtensions.ShowProgress="{Binding IsLoggingIn}"
                         Classes="Flat Rounded"
                         Command="{Binding LoginCommand}"
                         FontWeight="DemiBold">

--- a/SukiUI.Demo/Features/Effects/EffectsView.axaml
+++ b/SukiUI.Demo/Features/Effects/EffectsView.axaml
@@ -2,23 +2,23 @@
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:effects="clr-namespace:SukiUI.Demo.Features.Effects"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="effects:EffectsViewModel"
              mc:Ignorable="d">
     <Grid ColumnDefinitions="*,*" RowDefinitions="*,Auto,Auto">
-        <controls:GlassCard Margin="20"><avaloniaEdit:TextEditor  Name="Editor"
-                                                                  ShowLineNumbers="True"
-                                                                  Text="" /></controls:GlassCard>
+        <suki:GlassCard Margin="20"><avaloniaEdit:TextEditor  Name="Editor"
+                                                              ShowLineNumbers="True"
+                                                              Text="" /></suki:GlassCard>
         
-        <controls:InfoBar IsVisible="False" Margin="20,10" Name="ErrorText" IsClosable="False"
-                 Grid.Row="1" Severity="Error"
-                 Grid.Column="0" Title="Error" 
-                 />
+        <suki:InfoBar IsVisible="False" Margin="20,10" Name="ErrorText" IsClosable="False"
+                      Grid.Row="1" Severity="Error"
+                      Grid.Column="0" Title="Error" 
+        />
         <Button Grid.Row="2"
                 Grid.Column="0"
                 Classes="Flat Large" Margin="20"

--- a/SukiUI.Demo/Features/Playground/PlaygroundView.axaml
+++ b/SukiUI.Demo/Features/Playground/PlaygroundView.axaml
@@ -3,18 +3,17 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:avalonia="clr-namespace:Material.Icons.Avalonia;assembly=Material.Icons.Avalonia"
              xmlns:avaloniaEdit="https://github.com/avaloniaui/avaloniaedit"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:converters="clr-namespace:SukiUI.Demo.Converters"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:playground="clr-namespace:SukiUI.Demo.Features.Playground"
-             xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="playground:PlaygroundViewModel"
              mc:Ignorable="d">
-    <controls:SukiStackPage>
-        <controls:SukiStackPage.Content>
+    <suki:SukiStackPage>
+        <suki:SukiStackPage.Content>
 
             <SplitView Name="Playground"
                        CompactPaneLength="50"
@@ -48,22 +47,22 @@
 
                                 <TabItem Header="Buttons">
                                     <ScrollViewer Classes="Stack">
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ButtonsElements}">
+                                        <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ButtonsElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard MinHeight="100"
-                                                                        Margin="0,8"
-                                                                        CornerRadius="10"
-                                                                        IsInteractive="True"
-                                                                        PointerPressed="AddNewControls"
-                                                                        Tag="{Binding}">
+                                                    <suki:GlassCard MinHeight="100"
+                                                                    Margin="0,8"
+                                                                    CornerRadius="10"
+                                                                    IsInteractive="True"
+                                                                    PointerPressed="AddNewControls"
+                                                                    Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
                                                             <ContentControl HorizontalAlignment="Center"
                                                                             VerticalAlignment="Center"
                                                                             Content="{Binding ., Converter={x:Static converters:StringToControlConverter.Instance}}"
                                                                             IsHitTestVisible="False" />
                                                         </Viewbox>
-                                                    </controls:GlassCard>
+                                                    </suki:GlassCard>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
@@ -71,22 +70,22 @@
                                 </TabItem>
                                 <TabItem Header="Layout">
                                     <ScrollViewer Classes="Stack">
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding LayoutElements}">
+                                        <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding LayoutElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard MinHeight="100"
-                                                                        Margin="0,8"
-                                                                        CornerRadius="10"
-                                                                        IsInteractive="True"
-                                                                        PointerPressed="AddNewControls"
-                                                                        Tag="{Binding}">
+                                                    <suki:GlassCard MinHeight="100"
+                                                                    Margin="0,8"
+                                                                    CornerRadius="10"
+                                                                    IsInteractive="True"
+                                                                    PointerPressed="AddNewControls"
+                                                                    Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
                                                             <ContentControl HorizontalAlignment="Center"
                                                                             VerticalAlignment="Center"
                                                                             Content="{Binding ., Converter={x:Static converters:StringToControlConverter.Instance}}"
                                                                             IsHitTestVisible="False" />
                                                         </Viewbox>
-                                                    </controls:GlassCard>
+                                                    </suki:GlassCard>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
@@ -94,22 +93,22 @@
                                 </TabItem>
                                 <TabItem Header="Input">
                                     <ScrollViewer Classes="Stack">
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding InputsElements}">
+                                        <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding InputsElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard MinHeight="100"
-                                                                        Margin="0,8"
-                                                                        CornerRadius="10"
-                                                                        IsInteractive="True"
-                                                                        PointerPressed="AddNewControls"
-                                                                        Tag="{Binding}">
+                                                    <suki:GlassCard MinHeight="100"
+                                                                    Margin="0,8"
+                                                                    CornerRadius="10"
+                                                                    IsInteractive="True"
+                                                                    PointerPressed="AddNewControls"
+                                                                    Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
                                                             <ContentControl HorizontalAlignment="Center"
                                                                             VerticalAlignment="Center"
                                                                             Content="{Binding ., Converter={x:Static converters:StringToControlConverter.Instance}}"
                                                                             IsHitTestVisible="False" />
                                                         </Viewbox>
-                                                    </controls:GlassCard>
+                                                    </suki:GlassCard>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
@@ -117,22 +116,22 @@
                                 </TabItem>
                                 <TabItem Header="Progress">
                                     <ScrollViewer Classes="Stack">
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ProgressElements}">
+                                        <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ProgressElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard MinHeight="100"
-                                                                        Margin="0,8"
-                                                                        CornerRadius="10"
-                                                                        IsInteractive="True"
-                                                                        PointerPressed="AddNewControls"
-                                                                        Tag="{Binding}">
+                                                    <suki:GlassCard MinHeight="100"
+                                                                    Margin="0,8"
+                                                                    CornerRadius="10"
+                                                                    IsInteractive="True"
+                                                                    PointerPressed="AddNewControls"
+                                                                    Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
                                                             <ContentControl HorizontalAlignment="Center"
                                                                             VerticalAlignment="Center"
                                                                             Content="{Binding ., Converter={x:Static converters:StringToControlConverter.Instance}}"
                                                                             IsHitTestVisible="False" />
                                                         </Viewbox>
-                                                    </controls:GlassCard>
+                                                    </suki:GlassCard>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
@@ -140,22 +139,22 @@
                                 </TabItem>
                                 <TabItem Header="Lists">
                                     <ScrollViewer Classes="Stack">
-                                        <ItemsControl theme:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ListsElements}">
+                                        <ItemsControl suki:ItemsControlExtensions.AnimatedScroll="True" ItemsSource="{Binding ListsElements}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate>
-                                                    <controls:GlassCard MinHeight="100"
-                                                                        Margin="0,8"
-                                                                        CornerRadius="10"
-                                                                        IsInteractive="True"
-                                                                        PointerPressed="AddNewControls"
-                                                                        Tag="{Binding}">
+                                                    <suki:GlassCard MinHeight="100"
+                                                                    Margin="0,8"
+                                                                    CornerRadius="10"
+                                                                    IsInteractive="True"
+                                                                    PointerPressed="AddNewControls"
+                                                                    Tag="{Binding}">
                                                         <Viewbox StretchDirection="DownOnly">
                                                             <ContentControl HorizontalAlignment="Center"
                                                                             VerticalAlignment="Center"
                                                                             Content="{Binding ., Converter={x:Static converters:StringToControlConverter.Instance}}"
                                                                             IsHitTestVisible="False" />
                                                         </Viewbox>
-                                                    </controls:GlassCard>
+                                                    </suki:GlassCard>
                                                 </DataTemplate>
                                             </ItemsControl.ItemTemplate>
                                         </ItemsControl>
@@ -188,7 +187,7 @@
                     </Grid>
                 </SplitView.Pane>
                 <Grid ColumnDefinitions="*, 4, *">
-                    <controls:GlassCard Margin="20">
+                    <suki:GlassCard Margin="20">
                         <Grid RowDefinitions="*, Auto">
                             <avaloniaEdit:TextEditor Name="Editor"
                                                      ShowLineNumbers="True"
@@ -224,17 +223,17 @@
                                         </StackPanel>
                                     </Button>-->
                         </Grid>
-                    </controls:GlassCard>
+                    </suki:GlassCard>
                     <GridSplitter Grid.Row="0"
                                   Grid.Column="2"
                                   Background="Transparent"
                                   ResizeDirection="Columns" />
-                    <controls:GlassCard Name="GlassExample"
-                                        Grid.Row="0"
-                                        Grid.Column="2"
-                                        Margin="20" />
+                    <suki:GlassCard Name="GlassExample"
+                                    Grid.Row="0"
+                                    Grid.Column="2"
+                                    Margin="20" />
                 </Grid>
             </SplitView>
-        </controls:SukiStackPage.Content>
-    </controls:SukiStackPage>
+        </suki:SukiStackPage.Content>
+    </suki:SukiStackPage>
 </UserControl>

--- a/SukiUI.Demo/Features/Splash/SplashView.axaml
+++ b/SukiUI.Demo/Features/Splash/SplashView.axaml
@@ -1,7 +1,7 @@
 <UserControl x:Class="SukiUI.Demo.Features.Splash.SplashView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              xmlns:splash="clr-namespace:SukiUI.Demo.Features.Splash"
@@ -9,10 +9,10 @@
              d:DesignWidth="800"
              x:DataType="splash:SplashViewModel"
              mc:Ignorable="d">
-    <controls:GlassCard Margin="40"
-                        HorizontalAlignment="Center"
-                        VerticalAlignment="Center">
-        <controls:GroupBox Header="Welcome to the SukiUI Demo App.">
+    <suki:GlassCard Margin="40"
+                    HorizontalAlignment="Center"
+                    VerticalAlignment="Center">
+        <suki:GroupBox Header="Welcome to the SukiUI Demo App.">
             <StackPanel Classes="HeaderContent">
                 <Image Width="135"
                        Height="135"
@@ -35,6 +35,6 @@
                     If you see a control on one of the demo pages and would like to see how to use it in your own app, simply press the small tag icon to the bottom right of the control.
                 </TextBlock>
             </StackPanel>
-        </controls:GroupBox>
-    </controls:GlassCard>
+        </suki:GroupBox>
+    </suki:GlassCard>
 </UserControl>

--- a/SukiUI.Demo/Features/Theming/ThemingView.axaml
+++ b/SukiUI.Demo/Features/Theming/ThemingView.axaml
@@ -1,23 +1,22 @@
 <UserControl x:Class="SukiUI.Demo.Features.Theming.ThemingView"
              xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-             xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
              xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-             xmlns:models="clr-namespace:SukiUI.Models;assembly=SukiUI"
+             xmlns:suki="https://github.com/kikipoulet/SukiUI"
              xmlns:objectModel="clr-namespace:System.Collections.ObjectModel;assembly=System.ObjectModel"
              xmlns:theming="clr-namespace:SukiUI.Demo.Features.Theming"
              d:DesignHeight="450"
              d:DesignWidth="800"
              x:DataType="theming:ThemingViewModel"
              mc:Ignorable="d">
-    <controls:SukiStackPage Margin="20">
-        <controls:SukiStackPage.Content>
-            <controls:SettingsLayout Name="Theming">
-                <controls:SettingsLayout.Items>
-                    <objectModel:ObservableCollection x:TypeArguments="controls:SettingsLayoutItem">
-                        <controls:SettingsLayoutItem Header="Base Theme">
-                            <controls:SettingsLayoutItem.Content>
+    <suki:SukiStackPage Margin="20">
+        <suki:SukiStackPage.Content>
+            <suki:SettingsLayout Name="Theming">
+                <suki:SettingsLayout.Items>
+                    <objectModel:ObservableCollection x:TypeArguments="suki:SettingsLayoutItem">
+                        <suki:SettingsLayoutItem Header="Base Theme">
+                            <suki:SettingsLayoutItem.Content>
                                 <StackPanel HorizontalAlignment="Center"
                                             Orientation="Horizontal"
                                             Spacing="20">
@@ -60,11 +59,11 @@
                                         </Border>
                                     </RadioButton>
                                 </StackPanel>
-                            </controls:SettingsLayoutItem.Content>
-                        </controls:SettingsLayoutItem>
+                            </suki:SettingsLayoutItem.Content>
+                        </suki:SettingsLayoutItem>
 
-                        <controls:SettingsLayoutItem Header="Color Theme">
-                            <controls:SettingsLayoutItem.Content>
+                        <suki:SettingsLayoutItem Header="Color Theme">
+                            <suki:SettingsLayoutItem.Content>
                                 <ItemsControl HorizontalAlignment="Center" ItemsSource="{Binding AvailableColors}">
                                     <ItemsControl.ItemsPanel>
                                         <ItemsPanelTemplate>
@@ -74,7 +73,7 @@
                                         </ItemsPanelTemplate>
                                     </ItemsControl.ItemsPanel>
                                     <ItemsControl.ItemTemplate>
-                                        <DataTemplate x:DataType="models:SukiColorTheme">
+                                        <DataTemplate x:DataType="suki:SukiColorTheme">
                                             <RadioButton Width="50"
                                                          Height="50"
                                                          Classes="GigaChips"
@@ -89,13 +88,13 @@
                                         </DataTemplate>
                                     </ItemsControl.ItemTemplate>
                                 </ItemsControl>
-                            </controls:SettingsLayoutItem.Content>
-                        </controls:SettingsLayoutItem>
+                            </suki:SettingsLayoutItem.Content>
+                        </suki:SettingsLayoutItem>
 
-                        <controls:SettingsLayoutItem Header="Background">
-                            <controls:SettingsLayoutItem.Content>
+                        <suki:SettingsLayoutItem Header="Background">
+                            <suki:SettingsLayoutItem.Content>
                                 <StackPanel>
-                                <controls:GlassCard Padding="25" Margin="0,25,0,0">
+                                <suki:GlassCard Padding="25" Margin="0,25,0,0">
                                     <StackPanel Spacing="40">
                                         <DockPanel>
                                             <ToggleSwitch VerticalAlignment="Top"
@@ -129,8 +128,8 @@
                                         </DockPanel>
                                         
                                     </StackPanel>
-                                </controls:GlassCard>
-                                <controls:GlassCard Padding="25"  Margin="0,45,0,0">
+                                </suki:GlassCard>
+                                <suki:GlassCard Padding="25"  Margin="0,45,0,0">
                                     <StackPanel Spacing="40">
                                         <DockPanel>
                                             <ComboBox DockPanel.Dock="Right"
@@ -174,13 +173,13 @@
                                             </ItemsControl>
                                         </DockPanel>
                                     </StackPanel>
-                                </controls:GlassCard>
+                                </suki:GlassCard>
                                 </StackPanel>
-                            </controls:SettingsLayoutItem.Content>
-                        </controls:SettingsLayoutItem>
+                            </suki:SettingsLayoutItem.Content>
+                        </suki:SettingsLayoutItem>
                     </objectModel:ObservableCollection>
-                </controls:SettingsLayout.Items>
-            </controls:SettingsLayout>
-        </controls:SukiStackPage.Content>
-    </controls:SukiStackPage>
+                </suki:SettingsLayout.Items>
+            </suki:SettingsLayout>
+        </suki:SukiStackPage.Content>
+    </suki:SukiStackPage>
 </UserControl>

--- a/SukiUI.Demo/Styles/CompletionWindowStyles.axaml
+++ b/SukiUI.Demo/Styles/CompletionWindowStyles.axaml
@@ -1,7 +1,7 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:cc="clr-namespace:AvaloniaEdit.CodeCompletion;assembly=AvaloniaEdit"
-                    xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI">
+                    xmlns:suki="https://github.com/kikipoulet/SukiUI"
+                    xmlns:cc="clr-namespace:AvaloniaEdit.CodeCompletion;assembly=AvaloniaEdit">
     <ControlTheme x:Key="{x:Type cc:CompletionListBox}"
                   BasedOn="{StaticResource {x:Type ListBox}}"
                   TargetType="cc:CompletionListBox">
@@ -29,7 +29,7 @@
                         ClipToBounds="{TemplateBinding ClipToBounds}"
                         CornerRadius="{TemplateBinding CornerRadius}">
                     <Border.Resources>
-                        <theme:BiggestItemListBoxConverter x:Key="BiggestListitem" />
+                        <suki:BiggestItemListBoxConverter x:Key="BiggestListitem" />
                     </Border.Resources>
                     <Grid>
                         <ListBoxItem Margin="0,0,32,0"

--- a/SukiUI.Demo/Styles/GlassCardStyles.axaml
+++ b/SukiUI.Demo/Styles/GlassCardStyles.axaml
@@ -1,7 +1,7 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI">
-    <Style Selector="controls|GlassCard.HeaderCard">
+        xmlns:suki="https://github.com/kikipoulet/SukiUI">
+    <Style Selector="suki|GlassCard.HeaderCard">
         <Setter Property="Margin" Value="30,30,30,1" />
     </Style>
 </Styles>

--- a/SukiUI.Demo/Styles/WrapPanelStyles.axaml
+++ b/SukiUI.Demo/Styles/WrapPanelStyles.axaml
@@ -1,12 +1,11 @@
 <Styles xmlns="https://github.com/avaloniaui"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-        xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
-        xmlns:theme="clr-namespace:SukiUI.Theme;assembly=SukiUI">
+        xmlns:suki="https://github.com/kikipoulet/SukiUI">
     <Style Selector="WrapPanel.PageContainer">
         <Setter Property="Margin" Value="15,15,0,0" />
         <Setter Property="Orientation" Value="Horizontal" />
-        <Setter Property="theme:WrapPanelExtensions.AnimatedScroll" Value="True" />
-        <Style Selector="^ &gt; controls|GlassCard">
+        <Setter Property="suki:WrapPanelExtensions.AnimatedScroll" Value="True" />
+        <Style Selector="^ &gt; suki|GlassCard">
             <Setter Property="Margin" Value="15,15,15,15" />
         </Style>
     </Style>

--- a/SukiUI.Demo/SukiUIDemoView.axaml
+++ b/SukiUI.Demo/SukiUIDemoView.axaml
@@ -6,8 +6,7 @@
                  xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
                  xmlns:demo="clr-namespace:SukiUI.Demo"
                  xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
-                 xmlns:models="clr-namespace:SukiUI.Models;assembly=SukiUI"
-                 xmlns:suki="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+                 xmlns:suki="https://github.com/kikipoulet/SukiUI"
                  Title="SukiUI - Demo Application"
                  d:DesignHeight="450"
                  d:DesignWidth="800"
@@ -144,7 +143,7 @@
                       Header="Switch To..."
                       ItemsSource="{Binding Themes}">
                 <MenuItem.DataTemplates>
-                    <DataTemplate DataType="{x:Type models:SukiColorTheme}">
+                    <DataTemplate DataType="{x:Type suki:SukiColorTheme}">
                         <TextBlock Foreground="{Binding PrimaryBrush}" Text="{Binding DisplayName}" />
                     </DataTemplate>
                 </MenuItem.DataTemplates>

--- a/SukiUI.Dock/DocumentControl.axaml
+++ b/SukiUI.Dock/DocumentControl.axaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+                    xmlns:suki="https://github.com/kikipoulet/SukiUI"
                     xmlns:core="using:Dock.Model.Core"
                     xmlns:dmc="using:Dock.Model.Controls">
     <Design.PreviewWith>
@@ -18,7 +18,7 @@
         <Setter Property="Template">
             <ControlTemplate>
 
-                <controls:GlassCard Margin="5" Padding="12,15">
+                <suki:GlassCard Margin="5" Padding="12,15">
                     <DockPanel x:Name="PART_DockPanel"
                                x:CompileBindings="True"
                                x:DataType="dmc:IDocumentDock"
@@ -53,7 +53,7 @@
                             </DockableControl>
                         </Border>
                     </DockPanel>
-                </controls:GlassCard>
+                </suki:GlassCard>
             </ControlTemplate>
         </Setter>
 

--- a/SukiUI.Dock/ToolChromeControl.axaml
+++ b/SukiUI.Dock/ToolChromeControl.axaml
@@ -1,6 +1,6 @@
 ﻿<ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:converters="using:Dock.Avalonia.Converters"
+                    xmlns:converters="clr-namespace:Dock.Avalonia.Converters;assembly=SukiUI.Dock"
                     xmlns:controls="using:Dock.Model.Controls">
   <Design.PreviewWith>
     <ToolChromeControl Width="300" Height="400" />

--- a/SukiUI.Dock/ToolDockControl.axaml
+++ b/SukiUI.Dock/ToolDockControl.axaml
@@ -1,6 +1,6 @@
 <ResourceDictionary xmlns="https://github.com/avaloniaui"
                     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-                    xmlns:controls="clr-namespace:SukiUI.Controls;assembly=SukiUI"
+                    xmlns:suki="https://github.com/kikipoulet/SukiUI"
                     xmlns:converters="clr-namespace:Dock.Avalonia.Converters"
                     xmlns:core="using:Dock.Model.Core">
     <Design.PreviewWith>
@@ -17,7 +17,7 @@
                             CornerRadius="20"
                             IsVisible="{TemplateBinding Background,
                                                         Converter={x:Static converters:TransparentToTrueConverter.Instance}}" />
-                    <controls:GlassCard Margin="5" Padding="0">
+                    <suki:GlassCard Margin="5" Padding="0">
                         <Panel>
 
                             <Panel IsVisible="{TemplateBinding Background, Converter={x:Static converters:TransparentToTrueConverter.Instance}}">
@@ -44,7 +44,7 @@
                                 </ToolChromeControl>
                             </DockableControl>
                         </Panel>
-                    </controls:GlassCard>
+                    </suki:GlassCard>
                 </Panel>
             </ControlTemplate>
         </Setter>

--- a/SukiUI/Properties/AssemblyInfo.cs
+++ b/SukiUI/Properties/AssemblyInfo.cs
@@ -1,0 +1,9 @@
+﻿using Avalonia.Metadata;
+
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI")]
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI.Controls")]
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI.Converters")]
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI.Theme")]
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI.Models")]
+[assembly: XmlnsDefinition("https://github.com/kikipoulet/SukiUI", "SukiUI.Content")]
+[assembly: XmlnsPrefix("https://github.com/kikipoulet/SukiUI", "suki")]


### PR DESCRIPTION
set suki-ui reference namespace `https://github.com/kikipoulet/SukiUI` in .axaml file.

example: 
- old version
```xaml
<Application
    ...
    xmlns:sukiUi="clr-namespace:SukiUI;assembly=SukiUI"
    >
    <Application.Styles>
        <sukiUi:SukiTheme ThemeColor="Blue"  />
    </Application.Styles>
</Application>
```

- new version

```xaml
<Application
    ...
    xmlns:suki="https://github.com/kikipoulet/SukiUI"
    >
    <Application.Styles>
        <suki:SukiTheme ThemeColor="Blue"  />
    </Application.Styles>
</Application>
```



